### PR TITLE
restrict game, row and column entered by the users

### DIFF
--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -150,12 +150,17 @@ class BattleshipTransaction(transaction.Transaction):
 
             LOGGER.error("in check_valid, CREATE is not fully implemented")
         elif self._action == 'JOIN':
-            # TODO: Check that the game can be joined (the state is 'NEW')
 
             # Check that self._name is in the store (to verify 
             # that the game exists (see FIRE below).
+            state = store[self._name]['State']
+            LOGGER.info("state: %s" % state)
             if self._name not in store:
                 raise BattleshipException('Trying to join a game that does not exist')
+            elif (state != "NEW"):
+                # Check that the game can be joined (the state is 'NEW')
+                raise BattleshipException('The game cannot accept any new participant')
+                
 
             # TODO: Validate that self._board is a valid board (right size,
             # right content.

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -89,7 +89,9 @@ class BattleshipTransaction(transaction.Transaction):
         LOGGER.debug("minfo: %s", repr(minfo))
         self._name = minfo['Name'] if 'Name' in minfo else None
         self._action = minfo['Action'] if 'Action' in minfo else None
-        # TODO: handle 'Board', 'Column', 'Row' 
+        # TODO: handle 'Board', 'Row' 
+        self._column = minfo['Column'] if 'Column' in minfo else None
+        
 
     def __str__(self):
         try:

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -14,6 +14,7 @@
 # -----------------------------------------------------------------------------
 
 import logging
+import re
 
 from journal import transaction, global_store_manager
 from journal.messages import transaction_message
@@ -143,7 +144,10 @@ class BattleshipTransaction(transaction.Transaction):
             if self._name in store:
                 raise BattleshipException('game already exists')
 
-            # TODO: Restrict game name letters and numbers.
+            # Restrict game name letters and numbers.
+            if not re.match("^[a-zA-Z0-9]*$", self._name):
+                raise BattleshipException("Only letters a-z A-Z and numbers 0-9 are allowed in the game name!")
+
             LOGGER.error("in check_valid, CREATE is not fully implemented")
         elif self._action == 'JOIN':
             # TODO: Check that the game can be joined (the state is 'NEW')

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -91,6 +91,9 @@ class BattleshipTransaction(transaction.Transaction):
         self._action = minfo['Action'] if 'Action' in minfo else None
         # TODO: handle 'Board', 'Row' 
         self._column = minfo['Column'] if 'Column' in minfo else None
+
+        # self._column is valid (letter from A-J)
+        self.acceptable_columns = set('ABCDEFGHIJ')
         
 
     def __str__(self):
@@ -175,8 +178,8 @@ class BattleshipTransaction(transaction.Transaction):
                 raise BattleshipException('no such game')
             
             # Check that self._column is valid (letter from A-J)
-            acceptable_columns = set('ABCDEFGHIJ')
-            if not any((c in acceptable_columns) for c in self._column):
+            
+            if not any((c in self._acceptable_columns) for c in self._column):
                 raise BattleshipException('Acceptable columns letters are A to J')
 
             # TODO: Check that self._row is valid (number from 1-10)

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -174,7 +174,10 @@ class BattleshipTransaction(transaction.Transaction):
             if self._name not in store:
                 raise BattleshipException('no such game')
             
-            # TODO: Check that self._column is valid (letter from A-J)
+            # Check that self._column is valid (letter from A-J)
+            acceptable_columns = set('ABCDEFGHIJ')
+            if not any((c in acceptable_columns) for c in self._column):
+                raise BattleshipException('Acceptable columns letters are A to J')
 
             # TODO: Check that self._row is valid (number from 1-10)
 

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -152,8 +152,10 @@ class BattleshipTransaction(transaction.Transaction):
         elif self._action == 'JOIN':
             # TODO: Check that the game can be joined (the state is 'NEW')
 
-            # TODO: Check that self._name is in the store (to verify
+            # Check that self._name is in the store (to verify 
             # that the game exists (see FIRE below).
+            if self._name not in store:
+                raise BattleshipException('Trying to join a game that does not exist')
 
             # TODO: Validate that self._board is a valid board (right size,
             # right content.

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -89,8 +89,9 @@ class BattleshipTransaction(transaction.Transaction):
         LOGGER.debug("minfo: %s", repr(minfo))
         self._name = minfo['Name'] if 'Name' in minfo else None
         self._action = minfo['Action'] if 'Action' in minfo else None
-        # TODO: handle 'Board', 'Row' 
+        # TODO: handle 'Board'
         self._column = minfo['Column'] if 'Column' in minfo else None
+        self._row = minfo['Row'] if 'Row' in minfo else None
 
         # self._column is valid (letter from A-J)
         self._acceptable_columns = set('ABCDEFGHIJ')
@@ -182,7 +183,14 @@ class BattleshipTransaction(transaction.Transaction):
             if not any((c in self._acceptable_columns) for c in self._column):
                 raise BattleshipException('Acceptable columns letters are A to J')
 
-            # TODO: Check that self._row is valid (number from 1-10)
+            # Check that self._row is valid (number from 1-10)
+            try:
+                row = int(self._row)
+                if (row <1) or (row>10):
+                    raise BattleshipException('Acceptable rows numbers are 1 to 10')
+            except ValueError:
+                raise BattleshipException('Acceptable rows numbers are 1 to 10')
+            
 
             state = store[self._name]['State']
 

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -93,7 +93,7 @@ class BattleshipTransaction(transaction.Transaction):
         self._column = minfo['Column'] if 'Column' in minfo else None
 
         # self._column is valid (letter from A-J)
-        self.acceptable_columns = set('ABCDEFGHIJ')
+        self._acceptable_columns = set('ABCDEFGHIJ')
         
 
     def __str__(self):


### PR DESCRIPTION
- Restrict game name letters and numbers.
- Check that self._name is in the store (to verify that the game exists
- Check that the game can be joined (the state is 'NEW')
- add the Column as new property of the game
- Check that self._column is valid (letter from A-J)
- moved the list of acceptable columns in the **init**
- Fix in the code  
- Check that self._row is valid (number from 1-10)
