### PR TITLE
Feature to specify ships to use on board, and then implemented game end checking in apply

### DIFF
--- a/sawtooth_battleship/battleship_board.py
+++ b/sawtooth_battleship/battleship_board.py
@@ -20,7 +20,7 @@ import hashlib
 
 from enum import Enum
 
-from battleship_exceptions import BoardLayoutException
+from sawtooth_battleship.battleship_exceptions import BoardLayoutException
 
 
 LOGGER = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ class BoardLayout(object):
         return board
 
     def render_hashed(self, nonces):
-        hashed_board = [[None] * self.size for i in range(self.size)]
+        hashed_board = [[None] * self.size for _ in range(self.size)]
         clear_board = self.render()
 
         for row in xrange(0, self.size):
@@ -156,7 +156,7 @@ class BoardLayout(object):
                 try:
                     layout.append(position)
                     success = True
-                except BoardLayoutException, e:
+                except BoardLayoutException:
                     if attempts > max_placement_attempts:
                         LOGGER.debug("exceeded attempts, resetting...")
                         layout = BoardLayout(size)
@@ -200,7 +200,7 @@ class ShipPosition(object):
 
 
 def create_nonces(board_size):
-    nonces = [[None] * board_size for i in range(board_size)]
+    nonces = [[None] * board_size for _ in range(board_size)]
     for row in xrange(0, board_size):
         for col in xrange(0, board_size):
             nonces[row][col] = ''.join(

--- a/sawtooth_battleship/battleship_cli.py
+++ b/sawtooth_battleship/battleship_cli.py
@@ -263,14 +263,14 @@ def do_fire(args, config):
 
     data = load_data(config)
 
-    if not name in data['games']:
+    if name not in data['games']:
         raise BattleshipException(
             "no such game in local database: {}".format(name))
 
     client = BattleshipClient(base_url=url, keyfile=key_file)
     state = client.get_state()
 
-    if not name in state:
+    if name not in state:
         raise BattleshipException(
             "no such game: {}".format(name))
     state_game = state[name]
@@ -315,7 +315,7 @@ def do_join(args, config):
     game = state[name]
     ships = game['Ships']
 
-    if not name in data['games']:
+    if name not in data['games']:
         new_layout = BoardLayout.generate(ships=ships)
         data['games'][name] = {}
         data['games'][name]['layout'] = new_layout.serialize()
@@ -573,7 +573,7 @@ def load_data(config):
         with open(data_file, 'r') as fd:
             data = json.load(fd)
     else:
-        data = { 'games': {} }
+        data = {'games': {}}
 
     return data
 

--- a/sawtooth_battleship/battleship_client.py
+++ b/sawtooth_battleship/battleship_client.py
@@ -34,12 +34,13 @@ class BattleshipClient(SawtoothClient):
             name='BattleshipClient',
             keyfile=keyfile)
 
-    def create(self, name):
+    def create(self, name, ships):
         """
         """
         update = {
             'Action': 'CREATE',
-            'Name': name
+            'Name': name,
+            'Ships': ships
         }
 
         return self.sendtxn(

--- a/sawtooth_battleship/battleship_client.py
+++ b/sawtooth_battleship/battleship_client.py
@@ -48,7 +48,6 @@ class BattleshipClient(SawtoothClient):
             BattleshipTransactionMessage,
             update)
 
-
     def join(self, name, board):
         """
         """
@@ -62,7 +61,6 @@ class BattleshipClient(SawtoothClient):
             BattleshipTransaction,
             BattleshipTransactionMessage,
             update)
-
 
     def fire(self, name, column, row, reveal_space, reveal_nonce):
         """

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -104,7 +104,6 @@ class BattleshipTransaction(transaction.Transaction):
 
         # size of the board (10x10)
         self._size = 10
-        
 
     def __str__(self):
         try:
@@ -141,7 +140,7 @@ class BattleshipTransaction(transaction.Transaction):
 
         if not super(BattleshipTransaction, self).is_valid(store):
             raise BattleshipException("invalid transaction")
-        
+
         LOGGER.debug('checking %s', str(self))
 
         # Name (of the game) is always required
@@ -155,25 +154,29 @@ class BattleshipTransaction(transaction.Transaction):
         # The remaining validity rules depend upon which action has
         # been specified.
 
-        if self._action == 'CREATE':    
+        if self._action == 'CREATE':
             if self._name in store:
                 raise BattleshipException('game already exists')
 
             # Restrict game name letters and numbers.
             if not re.match("^[a-zA-Z0-9]*$", self._name):
-                raise BattleshipException("Only letters a-z A-Z and numbers 0-9 are allowed in the game name!")
+                raise BattleshipException(
+                    "Only letters a-z A-Z and numbers 0-9 are allowed in "
+                    "the game name!")
 
         elif self._action == 'JOIN':
 
-            # Check that self._name is in the store (to verify 
+            # Check that self._name is in the store (to verify
             # that the game exists (see FIRE below).
             state = store[self._name]['State']
             LOGGER.info("state: %s" % state)
             if self._name not in store:
-                raise BattleshipException('Trying to join a game that does not exist')
+                raise BattleshipException(
+                    'Trying to join a game that does not exist')
             elif (state != "NEW"):
                 # Check that the game can be joined (the state is 'NEW')
-                raise BattleshipException('The game cannot accept any new participant')
+                raise BattleshipException(
+                    'The game cannot accept any new participant')
 
             # Check that the game board is the right size (10x10)
             if len(self._board) != self._size:
@@ -193,25 +196,27 @@ class BattleshipTransaction(transaction.Transaction):
 
             if self._name not in store:
                 raise BattleshipException('no such game')
-            
+
             if self._column is None:
                 raise BattleshipException("Column is required")
 
             if self._row is None:
                 raise BattleshipException("Row is required")
-            
+
             # Check that self._column is valid (letter from A-J)
             if not any((c in self._acceptable_columns) for c in self._column):
-                raise BattleshipException('Acceptable columns letters are A to J')
+                raise BattleshipException(
+                    'Acceptable columns letters are A to J')
 
             # Check that self._row is valid (number from 1-10)
             try:
                 row = int(self._row)
-                if (row <1) or (row>10):
-                    raise BattleshipException('Acceptable rows numbers are 1 to 10')
+                if (row < 1) or (row > 10):
+                    raise BattleshipException(
+                        'Acceptable rows numbers are 1 to 10')
             except ValueError:
-                raise BattleshipException('Acceptable rows numbers are 1 to 10')
-            
+                raise BattleshipException(
+                    'Acceptable rows numbers are 1 to 10')
 
             state = store[self._name]['State']
 
@@ -254,7 +259,7 @@ class BattleshipTransaction(transaction.Transaction):
             if 'LastFireColumn' in store[self._name]:
                 if self._reveal_space is None or self._reveal_nonce is None:
                     raise BattleshipException(
-                            "Attempted to fire without revealing target")
+                        "Attempted to fire without revealing target")
 
                 if state == 'P1-NEXT':
                     hashed_board = 'HashedBoard1'
@@ -266,12 +271,13 @@ class BattleshipTransaction(transaction.Transaction):
                 hashed_space = hash_space(self._reveal_space,
                                           self._reveal_nonce)
                 if store[self._name][hashed_board][row][col] != hashed_space:
-                    raise BattleshipException("Hash mismatch on reveal: "
-                        "{} != {}".format(hashed_board[row][col], hashed_space))
+                    raise BattleshipException(
+                        "Hash mismatch on reveal: {} != {}".format(
+                            hashed_board[row][col], hashed_space))
 
         else:
-            raise BattleshipException('invalid action: {}'.format(self._action))
-
+            raise BattleshipException(
+                'invalid action: {}'.format(self._action))
 
     def apply(self, store):
         """Applies all the updates in the transaction to the transaction
@@ -291,7 +297,7 @@ class BattleshipTransaction(transaction.Transaction):
             # store.  if this is the second JOIN, set HashedBoard2 and
             # Player2 in the store.  Also, initialize TargetBoard1 and
             # TargetBoard2 as empty.
-            if not 'Player1' in game:
+            if 'Player1' not in game:
                 game['HashedBoard1'] = self._board
                 size = len(self._board)
                 game['TargetBoard1'] = [['?'] * size for i in range(size)]
@@ -340,7 +346,7 @@ class BattleshipTransaction(transaction.Transaction):
             # to P1-WIN or P2-WIN as appropriate
             total_ship_spaces = sum([len(ship) for ship in game['Ships']])
             if number_of_hits is not None and \
-                total_ship_spaces == number_of_hits:
+                    total_ship_spaces == number_of_hits:
                 if target_board == 'TargetBoard2':
                     game['State'] = 'P2-WIN'
                 else:
@@ -355,7 +361,6 @@ class BattleshipTransaction(transaction.Transaction):
         else:
             raise BattleshipException("invalid state: {}".format(state))
 
-         
     def dump(self):
         """Returns a dict with attributes from the transaction object.
 

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -91,6 +91,7 @@ class BattleshipTransaction(transaction.Transaction):
         self._name = minfo['Name'] if 'Name' in minfo else None
         self._action = minfo['Action'] if 'Action' in minfo else None
         self._board = minfo['Board'] if 'Board' in minfo else None
+        self._ships = minfo['Ships'] if 'Ships' in minfo else None
         self._column = minfo['Column'] if 'Column' in minfo else None
         self._row = minfo['Row'] if 'Row' in minfo else None
         self._reveal_space = minfo['RevealSpace'] \
@@ -282,7 +283,7 @@ class BattleshipTransaction(transaction.Transaction):
         LOGGER.debug('apply %s', str(self))
 
         if self._action == 'CREATE':
-            store[self._name] = { 'State': 'NEW' }
+            store[self._name] = {'State': 'NEW', 'Ships': self._ships}
         elif self._action == 'JOIN':
             game = store[self._name].copy()
 
@@ -355,6 +356,7 @@ class BattleshipTransaction(transaction.Transaction):
 
         result['Name'] = self._name
         result['Action'] = self._action
+        result['Ships'] = self._ships
         if self._action == 'JOIN':
             result['Board'] = self._board
         if self._action == 'FIRE':

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -351,10 +351,6 @@ class BattleshipTransaction(transaction.Transaction):
             elif game['State'] == 'P2-NEXT':
                 game['State'] = 'P1-NEXT'
 
-            # TODO: Remove this logging statement when all other TODOs
-            # have been resolved for FIRE
-            LOGGER.error("in apply, FIRE is not fully implemented")
-
             store[self._name] = game
         else:
             raise BattleshipException("invalid state: {}".format(state))

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -169,11 +169,11 @@ class BattleshipTransaction(transaction.Transaction):
             # Check that self._name is in the store (to verify
             # that the game exists (see FIRE below).
             state = store[self._name]['State']
-            LOGGER.info("state: %s" % state)
+            LOGGER.info("state: %s", state)
             if self._name not in store:
                 raise BattleshipException(
                     'Trying to join a game that does not exist')
-            elif (state != "NEW"):
+            elif state != "NEW":
                 # Check that the game can be joined (the state is 'NEW')
                 raise BattleshipException(
                     'The game cannot accept any new participant')
@@ -300,12 +300,12 @@ class BattleshipTransaction(transaction.Transaction):
             if 'Player1' not in game:
                 game['HashedBoard1'] = self._board
                 size = len(self._board)
-                game['TargetBoard1'] = [['?'] * size for i in range(size)]
+                game['TargetBoard1'] = [['?'] * size for _ in range(size)]
                 game['Player1'] = self.OriginatorID
             else:
                 game['HashedBoard2'] = self._board
                 size = len(self._board)
-                game['TargetBoard2'] = [['?'] * size for i in range(size)]
+                game['TargetBoard2'] = [['?'] * size for _ in range(size)]
                 game['Player2'] = self.OriginatorID
 
                 # Move to 'P1-NEXT' as both boards have been entered.
@@ -359,7 +359,8 @@ class BattleshipTransaction(transaction.Transaction):
 
             store[self._name] = game
         else:
-            raise BattleshipException("invalid state: {}".format(state))
+            raise BattleshipException(
+                "invalid state: {}".format(store[self._name].copy))
 
     def dump(self):
         """Returns a dict with attributes from the transaction object.

--- a/sawtooth_battleship/txn_family.py
+++ b/sawtooth_battleship/txn_family.py
@@ -323,14 +323,28 @@ class BattleshipTransaction(transaction.Transaction):
                 else:
                     game[target_board][row][col] = 'M'
 
+                # calculate number of hits for later determination
+                # of win
+                number_of_hits = sum(sum([1 if space == 'H' else 0
+                                          for space in row])
+                                     for row in game[target_board])
+            else:
+                number_of_hits = None
 
             # Update LastFireColumn and LastFireRow in the store so
             # they can be used in the next transaction.
             game['LastFireColumn'] = self._column
             game['LastFireRow'] = self._row
 
-            # TODO: detect if the game has been won, changing the State
+            # if the game has been won, change the State
             # to P1-WIN or P2-WIN as appropriate
+            total_ship_spaces = sum([len(ship) for ship in game['Ships']])
+            if number_of_hits is not None and \
+                total_ship_spaces == number_of_hits:
+                if target_board == 'TargetBoard2':
+                    game['State'] = 'P2-WIN'
+                else:
+                    game['State'] = 'P1-WIN'
 
             if game['State'] == 'P1-NEXT':
                 game['State'] = 'P2-NEXT'

--- a/tests/test_bs_board.py
+++ b/tests/test_bs_board.py
@@ -24,6 +24,7 @@ class TestSawtoothBsBoard(unittest.TestCase):
     def test_board_creation(self):
         board = bs.Board()
         enc_board = board.create_game()
-        dcrpt_space = board.decrypt_space(enc_board[5], board.secret_board_keys[5])
+        dcrpt_space = board.decrypt_space(enc_board[5],
+                                          board.secret_board_keys[5])
         orig_space = board.secret_board[5]
         self.assertEquals(orig_space, dcrpt_space)


### PR DESCRIPTION
Updated cli to use --ships (e.g. 'AAA S BB') to specify ships in do_create. In do_join the state is queried and the ships are used to generate a board. In BattleshipTransaction the ships are used to determine who wins. A double comprehension with 2 sums are used. I could refactor to make it more clear.

Lint errors were fixed and lint runs without error.
